### PR TITLE
save scenarios.json directly in the root path of the results

### DIFF
--- a/tests/testcases/run_test.py
+++ b/tests/testcases/run_test.py
@@ -60,7 +60,7 @@ def compare_variables_results(test_model: str, results: Results, folder_path: st
                 test_values = test_variables[test_model][s]
                 for c in test_values:
                     if c in results.solution_loader.components:
-                        values = results.get_df(c)[s]
+                        values = results.get_df(c,scenario_name=s)
                         for test_value in test_values[c]:
                             if isinstance(test_value["index"],list):
                                 test_index = tuple(test_value["index"])
@@ -520,4 +520,4 @@ if __name__ == "__main__":
 
     config.solver.keep_files = False
     folder_path = os.path.dirname(__file__)
-    test_3c(config, folder_path)
+    test_1a(config, folder_path)

--- a/zen_garden/postprocess/postprocess.py
+++ b/zen_garden/postprocess/postprocess.py
@@ -386,21 +386,6 @@ class Postprocess:
         # only save the scenarios at the highest level
         root_path = Path(self.analysis.folder_output).joinpath(self.model_name)
         fname = root_path.joinpath('scenarios')
-        # # This we only need to save once
-        # # check if MF within scenario analysis
-        # if isinstance(self.subfolder, tuple):
-        #     # check if there are sub_scenarios (parent must then be the name of the parent scenario)
-        #     if not self.subfolder[0].parent == Path("."):
-        #         fname = self.name_dir.parent.parent.parent.joinpath('scenarios')
-        #     else:
-        #         # MF with in scenario analysis without sub-scenarios
-        #         fname = self.name_dir.parent.parent.joinpath('scenarios')
-        # # only MF or only scenario analysis
-        # elif self.subfolder != Path(""):
-        #     fname = self.name_dir.parent.joinpath('scenarios')
-        # # neither MF nor scenario analysis
-        # else:
-        #     fname = self.name_dir.joinpath('scenarios')
         self.write_file(fname, self.scenarios, format="json")
 
     def save_unit_definitions(self):

--- a/zen_garden/postprocess/postprocess.py
+++ b/zen_garden/postprocess/postprocess.py
@@ -18,6 +18,7 @@ import xarray as xr
 from filelock import FileLock
 import yaml
 from pydantic import BaseModel
+from win32comext.authorization.demos.EditSecurity import fname
 
 from ..model.optimization_setup import OptimizationSetup
 
@@ -384,24 +385,25 @@ class Postprocess:
         """
         Saves the scenario dict as json
         """
-
-        # This we only need to save once
-        # check if MF within scenario analysis
-        if isinstance(self.subfolder, tuple):
-            # check if there are sub_scenarios (parent must then be the name of the parent scenario)
-            if not self.subfolder[0].parent == Path("."):
-                fname = self.name_dir.parent.parent.parent.joinpath('scenarios')
-            else:
-                # MF with in scenario analysis without sub-scenarios
-                fname = self.name_dir.parent.parent.joinpath('scenarios')
-        # only MF or only scenario analysis
-        elif self.subfolder != Path(""):
-            fname = self.name_dir.parent.joinpath('scenarios')
-        # neither MF nor scenario analysis
-        else:
-            fname = self.name_dir.joinpath('scenarios')
+        # only save the scenarios at the highest level
+        root_path = Path(self.analysis.folder_output).joinpath(self.model_name)
+        fname = root_path.joinpath('scenarios')
+        # # This we only need to save once
+        # # check if MF within scenario analysis
+        # if isinstance(self.subfolder, tuple):
+        #     # check if there are sub_scenarios (parent must then be the name of the parent scenario)
+        #     if not self.subfolder[0].parent == Path("."):
+        #         fname = self.name_dir.parent.parent.parent.joinpath('scenarios')
+        #     else:
+        #         # MF with in scenario analysis without sub-scenarios
+        #         fname = self.name_dir.parent.parent.joinpath('scenarios')
+        # # only MF or only scenario analysis
+        # elif self.subfolder != Path(""):
+        #     fname = self.name_dir.parent.joinpath('scenarios')
+        # # neither MF nor scenario analysis
+        # else:
+        #     fname = self.name_dir.joinpath('scenarios')
         self.write_file(fname, self.scenarios, format="json")
-
 
     def save_unit_definitions(self):
         """

--- a/zen_garden/postprocess/postprocess.py
+++ b/zen_garden/postprocess/postprocess.py
@@ -8,7 +8,6 @@ import logging
 import os
 from pathlib import Path
 
-import h5py
 import numpy as np
 import pint
 from tables import NaturalNameWarning
@@ -18,7 +17,6 @@ import xarray as xr
 from filelock import FileLock
 import yaml
 from pydantic import BaseModel
-from win32comext.authorization.demos.EditSecurity import fname
 
 from ..model.optimization_setup import OptimizationSetup
 

--- a/zen_garden/postprocess/results/results.py
+++ b/zen_garden/postprocess/results/results.py
@@ -60,7 +60,7 @@ class Results:
         """
 
         scenario_names = (
-            self.solution_loader.scenarios.keys()
+            list(self.solution_loader.scenarios.keys())
             if scenario_name is None
             else [scenario_name]
         )


### PR DESCRIPTION
This should fix the issue that `scenarios.json` was put in the folder of each scenario and not in the root level of the results.
But why did we have the different cases there in the first place, any idea @johburger ? I've left the old code in there for now so that we can discuss it.


## Changes proposed in this Pull Request


## Checklist

- [x] Code changes have been tested locally.
- [x] Code changes are sufficiently documented, i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] A note for the release notes `docs/files/release_notes.rst` is included.
- [x] Breaking changes are documented in the `docs` and are communicated to the user (if applicable).
- [x] Newly introduced dependencies are added to `pyproject.toml` (if applicable).
- [x] Tests for new features were added (if applicable).
