### PR TITLE
Fix app_name in the browser from being "None" by default.

### DIFF
--- a/zen_garden/visualization.py
+++ b/zen_garden/visualization.py
@@ -11,6 +11,8 @@ from typing import Optional
 def start(path: str = "./outputs", api_url: Optional[str] = None, port: int = 8000, app_name: str = ''):
     if api_url is None:
         api_url = f"http://127.0.0.1:{port}/api/"
+    if app_name is None:
+        app_name = ""
 
     zen_temple.config.config.SOLUTION_FOLDER = path
     env_path = os.path.join(


### PR DESCRIPTION
## Changes proposed in this Pull Request

In this PR I fix a small issue where the app name in the browser was "None" by default. Now it shows the default configured in ZEN explorer, i.e. "ZEN-garden Visualization".

## Checklist

- [x] Code changes have been tested locally.
- [x] Code changes are sufficiently documented, i.e. new functions contain docstrings and further explanations may be given in `docs`.
- [ ] A note for the release notes `docs/files/release_notes.rst` is included.
- [x] Breaking changes are documented in the `docs` and are communicated to the user (if applicable).
- [x] Newly introduced dependencies are added to `pyproject.toml` (if applicable).
- [x] Tests for new features were added (if applicable).
