### PR TITLE
Bug fixes for IIS

### DIFF
--- a/zen_garden/utils.py
+++ b/zen_garden/utils.py
@@ -420,7 +420,7 @@ class IISConstraintParser(object):
 
         name = constraints.get_name_by_label(value)
         con = constraints[name]
-        indices = [i[0] for i in np.where(con.values == value)]
+        indices = [i[0] for i in np.where(con.labels.values == value)]
 
         # Extract the coordinates from the indices
         coord = {


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
- In the new `linopy` version, the class `Constraint` does not have the attribute `values` anymore. This caused errors in the writing of the IIS file in case of infeasibility, specifically in `utils.py` -> `get_label_position(constraints, value)` -> `indices = [i[0] for i in np.where(con.values == value)]`. This has been fixed by replacing `con.values` with `con.labels.values`.

## Checklist

### PR structure
- [x] The PR has a descriptive title.
