### PR TITLE
fix charge_storage_binary symbol in documentation #skiptests

### DIFF
--- a/docs/files/zen_garden_in_detail/tables/variables/storage_technology_variables.csv
+++ b/docs/files/zen_garden_in_detail/tables/variables/storage_technology_variables.csv
@@ -3,4 +3,4 @@ Variable Name;Time Step Type;Symbol;Doc String;Unit Category
 ``flow_storage_discharge``;``set_time_steps_operation``;:math:`\overline{H}_{k,n,t,y}`;carrier flow out of storage technology on node i and time t;{"energy_quantity": 1, "time": -1}
 ``storage_level``;``set_time_steps_storage_level``;:math:`L_{k,n,t,y}`;storage level of storage technology on node in each storage time step;{"energy_quantity": 1}
 ``flow_storage_spillage``;``set_time_steps_operation``;:math:`Y_{k,n,t,y}`;energy spillage for storage technology;{"energy_quantity": 1, "time": -1}
-``charge_storage_binary``;``set_time_steps_operation``;:math:`B^{\\mathrm{charge}}_{k,n,t,y}`;binary variable indicating whether the storage technology is in charging mode (1) or discharging mode (0);{}
+``charge_storage_binary``;``set_time_steps_operation``;:math:`B^\mathrm{charge}_{k,n,t,y}`;binary variable indicating whether the storage technology is in charging mode (1) or discharging mode (0);{}


### PR DESCRIPTION
## Changes proposed in this Pull Request
small fix in symbol for documentaion

## Checklist
Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.

### Documentation
- [x] Changes in the parameters, variables, sets, or constraints are added to `docs/files/zen_garden_in_detail/sets_params_constraints.rst` and `docs/files/zen_garden_in_detail/mathematical_formulation.rst`

