### PR TITLE
fix typo and bug for depreciation time

### DIFF
--- a/docs/files/zen_garden_in_detail/tables/parameters/technology_parameters.csv
+++ b/docs/files/zen_garden_in_detail/tables/parameters/technology_parameters.csv
@@ -6,7 +6,7 @@ Parameter Name;Symbol;Time Step Type;Doc String;Unit Category
 ``capacity_addition_max``;:math:`\Delta s^\mathrm{max}_{h,s,p,y}`;temporal immutable;Parameter which specifies the maximum capacity addition that can be installed;"{""energy_quantity"": 1, ""time"": -1}"
 ``capacity_addition_unbounded``;:math:`\zeta_h`;temporal immutable;Parameter which specifies the unbounded capacity addition that can be added each year (only for delayed technology deployment);"{""energy_quantity"": 1, ""time"": -1}"
 ``lifetime_existing``;:math:`l^\mathrm{ex}_h`;temporal immutable;Parameter which specifies the remaining lifetime of an existing technology;{}
-``deprecation_time``;:math: `dp_h`;temporal immutable;Parameter which specifies the deprecation time of invested technologies (optional, default value is the lifetime);{}
+``depreciation_time``;:math: `dp_h`;temporal immutable;Parameter which specifies the depreciation time of invested technologies (optional, default value is the lifetime, if );{}
 ``capex_capacity_existing``;-;temporal immutable;Parameter which specifies the total capex of an existing technology which still has to be paid;"{""money"": 1, ""energy_quantity"": -1}"
 ``opex_specific_variable``;:math:`\beta_{h,y}`;``set_time_steps_operation``;Parameter which specifies the variable specific opex;"{""money"": 1, ""energy_quantity"": -1}"
 ``opex_specific_fixed``;:math:`\gamma_{h,y}`;``set_time_steps_yearly``;Parameter which specifies the fixed annual specific opex;"{""money"": 1, ""energy_quantity"": -1, ""time"": 1}"

--- a/tests/testcases/test_1h/set_technologies/set_conversion_technologies/natural_gas_boiler/attributes.json
+++ b/tests/testcases/test_1h/set_technologies/set_conversion_technologies/natural_gas_boiler/attributes.json
@@ -27,7 +27,7 @@
     "default_value": 25.0,
     "unit": "1"
   },
-  "deprecation_time": {
+  "depreciation_time": {
   "default_value": 1.0,
   "unit": "1"
   },

--- a/tests/testcases/test_variables.json
+++ b/tests/testcases/test_variables.json
@@ -607,7 +607,7 @@
                     "value": 100.0
                 }
             ],
-            "deprecation_time": [
+            "depreciation_time": [
                 {
                     "index": ["natural_gas_boiler"],
                     "value": 1.0


### PR DESCRIPTION

## Changes proposed in this Pull Request
Typo fix and adapt depreciation time to interval between years if the depreciation time is smaller than the interval between the years.  

## Checklist
Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.
- [x] The corresponding issue is linked with # in the PR description.

### Code quality
- [ ] Newly introduced dependencies are added to `pyproject.toml`.
- [ ] Tests for new features were added:
  - [ ] A new test folder is added or an existing test folder is adapted
  - [ ] The test is added to `run_tests.py` and `docu_test_cases.md`
  - [ ] The tested variables are added to `test_variables.json`
  - [ ] Code changes have been tested locally and all tests pass

### Code changes
- [x] If the name of an existing parameter is changed, the new and old name are added to `zen_garden/preprocess/parameter_change_log.py`
- [x] If a new parameter is added, add the default value (0, 1, or `np.inf` allowed) and a parameter with the same unit are added to `zen_garden/preprocess/parameter_change_log.py`
- [x] If the name of an existing variable is changed and the variable is used in the visualization platform, the name change is added to `variable_versions` in the [ZEN-temple code](https://github.com/ZEN-universe/ZEN-temple/blob/main/src/zen_temple/utils.py)

### Documentation
- [x] Code changes are sufficiently documented, i.e. new functions contain docstrings
- [x] Changes in the parameters, variables, sets, or constraints are added to `docs/files/zen_garden_in_detail/sets_params_constraints.rst` and `docs/files/zen_garden_in_detail/mathematical_formulation.rst`
- [x] Changes in the config are added to `docs/files/zen_garden_in_detail/configurations.rst`
- [x] Additional features are added to `docs/files/zen_garden_in_detail/additional_features.rst`
- [x] Other changes are documented in the corresponding section of the documentation
