### PR TITLE
Define is_per_energy and is_per_time outside of try-except block.

### DIFF
--- a/zen_garden/postprocess/results/results.py
+++ b/zen_garden/postprocess/results/results.py
@@ -536,6 +536,8 @@ class Results:
             return u
         timestep_type = component.timestep_type
 
+        is_per_energy = False
+        is_per_time = False
         try:
             u = self.ureg.parse_expression(u)
             dim = u.dimensionality


### PR DESCRIPTION
I got an `UnboundLocalError` in this code, because it cannot find `is_per_energy`and `is_per_time` variables in the except block. This PR fixes that issue by defining these two variables before the try-except block.

### PR structure
- [x] The PR has a descriptive title.
