### PR TITLE
Allow for newer ZEN temple versions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "linopy",
     "requests",
     "ipykernel",
-    "zen-temple==0.7.0"
+    "zen-temple>=0.7.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Lifts the requirement for the exact ZEN temple version `0.7.0` and allows newer versions to be installed.