### PR TITLE
Fix bug when indexing results with only one index level 

### DIFF
--- a/docs/files/zen_garden_in_detail/tables/solver_settings.csv
+++ b/docs/files/zen_garden_in_detail/tables/solver_settings.csv
@@ -2,7 +2,7 @@ Key;Type;Default Value;Description
 ``name``;``str``;``highs``;select solver
 ``solver_options``;``SolverOptions``;``SolverOptions()``;pass solver options to the selected solver
 ``save_duals``;``bool``;``False``;if true, dual variables are computed, otherwise, computation of dual variables is skipped
-``save_parameters``;``bool``;``False``;if true, parameters are saved, otherwise, parameters are not saved
+``save_parameters``;``bool``;``True``;if true, parameters are saved, otherwise, parameters are not saved
 ``selected_saved_parameters``;``list[str]``;[];list of parameters to save. If empty, all parameters are saved.
 ``selected_saved_variables``;``list[str]``;[];list of variables to save. If empty, all variables are saved.
 ``selected_saved_variables_operation``;``list[str]``;[];list of variables to save in the operation-only phase (only if system setting ``include_operation_only_phase`` is ``True``). If empty, all variables are saved.

--- a/zen_garden/utils.py
+++ b/zen_garden/utils.py
@@ -215,50 +215,52 @@ def xr_like(fill_value, dtype, other, dims):
     return da
 
 def reformat_slicing_index(index, component) -> tuple[str]:
-        """ reformats the slicing index to a tuple of strings that is readable by pytables
-        :param index: slicing index of the resulting dataframe
-        :param component: component for which the index is reformatted
-        :return: reformatted index
-        """
-        if index is None:
-            return tuple()
-        index_names = component.index_names
-        if isinstance(index, str) or isinstance(index, float) or isinstance(index, int):
-            index_name = index_names[0]
-            ref_index = (f"{index_name} == {index}",)
-        elif isinstance(index, list):
-            index_name = index_names[0]
-            ref_index = (f"{index_name} in {index}",)
-        elif isinstance(index, dict):
-            ref_index = []
-            for key, value in index.items():
-                if key not in index_names:
-                    warnings.warn(f"Invalid index name '{key}' in index. Skipping.", Warning)
-                    continue
-                if isinstance(value, list):
-                    ref_index.append(f"{key} in {value}")
-                else:
-                    ref_index.append(f"{key} == {value}")
-            ref_index = tuple(ref_index)
-        elif isinstance(index, tuple):
-            ref_index = []
-            if len(index) > len(index_names):
-                warnings.warn(f"Index length {len(index)} is longer than the number of index dimensions {len(index_names)}. Check selected index.", Warning)
-            for i, index_name in enumerate(index_names):
-                if i >= len(index):
-                    break
-                if index[i] is None:
-                    continue
-                elif isinstance(index[i], list):
-                    ref_index.append(f"{index_name} in {index[i]}")
-                else:
-                    ref_index.append(f"{index_name} == {index[i]}")
-            ref_index = tuple(ref_index)
-        else:
-            warnings.warn(f"Invalid index type {type(index)}. Skipping.", Warning)
-            ref_index = tuple()
+    """ reformats the slicing index to a tuple of strings that is readable by pytables
+    :param index: slicing index of the resulting dataframe
+    :param component: component for which the index is reformatted
+    :return: reformatted index
+    """
+    if index is None:
+        return tuple()
+    index_names = component.index_names
+    if isinstance(index, str) or isinstance(index, float) or isinstance(index, int):
+        index_name = index_names[0]
+        ref_index = (f"{index_name} == {index}",)
+        if len(index_names) == 1:
+            ref_index = (f"index == {index}",)
+    elif isinstance(index, list):
+        index_name = index_names[0]
+        ref_index = (f"{index_name} in {index}",)
+    elif isinstance(index, dict):
+        ref_index = []
+        for key, value in index.items():
+            if key not in index_names:
+                warnings.warn(f"Invalid index name '{key}' in index. Skipping.", Warning)
+                continue
+            if isinstance(value, list):
+                ref_index.append(f"{key} in {value}")
+            else:
+                ref_index.append(f"{key} == {value}")
+        ref_index = tuple(ref_index)
+    elif isinstance(index, tuple):
+        ref_index = []
+        if len(index) > len(index_names):
+            warnings.warn(f"Index length {len(index)} is longer than the number of index dimensions {len(index_names)}. Check selected index.", Warning)
+        for i, index_name in enumerate(index_names):
+            if i >= len(index):
+                break
+            if index[i] is None:
+                continue
+            elif isinstance(index[i], list):
+                ref_index.append(f"{index_name} in {index[i]}")
+            else:
+                ref_index.append(f"{index_name} == {index[i]}")
+        ref_index = tuple(ref_index)
+    else:
+        warnings.warn(f"Invalid index type {type(index)}. Skipping.", Warning)
+        ref_index = tuple()
 
-        return ref_index
+    return ref_index
 
 def get_label_position(obj,label:int):
     """ Get dict of index and coordinate for variable or constraint labels."""


### PR DESCRIPTION
Closes #858 

## Changes proposed in this Pull Request
Reading out indexed results with only one index level was not working due to the way, h5 files are read in with pandas. 

### PR structure
- [x] The PR has a descriptive title.
- [x] The corresponding issue is linked with # in the PR description.