### PR TITLE
Improve API Documentation of Default Configurations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,11 +48,19 @@ extensions = ['sphinx.ext.autodoc',
 # allow errors in the notebooks
 nbsphinx_allow_errors = True
 
+# Generate .rst files when encountering an autosummary directive
+autosummary_generate = True
+autosummary_generate_overwrite = False
+
+
 # Specify the special members to include in the documentation
 autodoc_default_options = {
     'members': True,
     'special-members': '__init__',
 }
+
+# Prevent Spynx from showing nested defaults and typehints.
+autodoc_typehints_format = "short"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/files/api/model.rst
+++ b/docs/files/api/model.rst
@@ -7,8 +7,13 @@ General
 .. autosummary::
    :toctree: generated
 
-    zen_garden.model.optimization_setup
-    zen_garden.model.default_config
+   zen_garden.model.optimization_setup
+
+.. autosummary::
+   :toctree: modules
+
+   zen_garden.model.default_config
+
 
 Objects
 =======
@@ -19,6 +24,7 @@ Objects
     zen_garden.model.objects.element
     zen_garden.model.objects.energy_system
     zen_garden.model.objects.time_steps
+
 
 Carriers
 --------

--- a/docs/files/api/modules/zen_garden.model.default_config.rst
+++ b/docs/files/api/modules/zen_garden.model.default_config.rst
@@ -1,0 +1,42 @@
+﻿zen\_garden.model.default\_config
+=================================
+
+.. automodule:: zen_garden.model.default_config
+   :exclude-members: Subscriptable, Analysis, Config, HeaderDataInputs, Solver, Subsets, System, TimeSeriesAggregation  
+
+
+.. autoclass:: zen_garden.model.default_config.Analysis
+   :exclude-members: model_config
+
+.. autoclass:: zen_garden.model.default_config.Config
+   :exclude-members: model_config
+
+.. autoclass:: zen_garden.model.default_config.HeaderDataInputs
+   :exclude-members: model_config
+
+.. autoclass:: zen_garden.model.default_config.Solver
+   :exclude-members: model_config
+
+.. autoclass:: zen_garden.model.default_config.Subscriptable
+   :exclude-members: model_config
+   
+.. autoclass:: zen_garden.model.default_config.Subsets
+   :exclude-members: model_config
+
+.. autoclass:: zen_garden.model.default_config.System
+   :exclude-members: model_config
+
+.. autoclass:: zen_garden.model.default_config.TimeSeriesAggregation
+   :exclude-members: model_config
+
+
+
+
+
+
+   
+   
+   
+
+
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -25,6 +25,14 @@ if errorlevel 9009 (
 
 if "%1" == "" goto help
 
+if "%1" == "clean" (
+    if exist files\api\generated\*.rst (
+        echo Cleaning 'files/api/generated/' folder...
+        del /s /q files\api\generated\*.rst > nul
+    )
+)
+
+
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 

--- a/zen_garden/model/default_config.py
+++ b/zen_garden/model/default_config.py
@@ -1,7 +1,34 @@
 """
-Default configuration.
+Set default configurations in ZEN_garden.
 
-Changes from the default values are specified in config.py (folders data/tests) and system.py (individual datasets)
+This module defines default values for all configurations in ZEN_garden. The 
+class :class:`Config` serves as a container grouping all model configurations.
+The configurations are further organized in a class structure that resembles
+that of the ZEN-garden input data. The :class:`Config` class thus links to the four 
+main configuration types (``analysis``, ``solver``, ``system``, and ``scenario``), 
+each defined using separate class. Default configurations for the ``system.json`` 
+configurations are located in the class :class:`System`. Whenever a 
+configuration consists of a dictionary, a new class is defined 
+to provide a template for the configuration and define all required
+default values.  
+
+The current structure of classes in which defaults are set is as follows:
+
+.. code-block::
+
+    Config
+    |--Analysis
+    |  |--Subsets
+    |  |--HeaderDataInputs
+    |  `--TimeSeriesAggregation
+    |
+    |--Solver
+    |--System
+    `--Scenario
+
+
+Default values are overwritten by any chances specified in the input files
+``system.json``, ``scenarios.json``, and ``config.json``.
 """
 
 from pydantic import BaseModel,ConfigDict, create_model
@@ -9,6 +36,21 @@ from typing import Any, Optional, Union, get_type_hints
 
 
 class Subscriptable(BaseModel):
+    """
+    Allows dictionary-like access to class attributes.
+
+    This class allows dictionary-like access to class attributes, such as
+    ``obj["key"]`` instead of ``obj.key``. Similarly, attribute values can
+    be changed in a dictionary like fashion ``obj["key"] = new_value``. Lastly,
+    attribute names and values can be called using the methods ``.keys()``,
+    ``.values()``, and ``.items()`` like in a normal dictionary. 
+
+    Inherits from:
+        :class:`BaseModel` - Class from the Pydantic package which provides
+        advanced features in input data handling and validation. 
+
+    """
+
     model_config = ConfigDict(extra="allow")
 
     def __getitem__(self, __name: str) -> Any:
@@ -36,9 +78,22 @@ class Subsets(Subscriptable):
 
 
 class HeaderDataInputs(Subscriptable):
+    
     """
-    Header data inputs for the model
+    Maps input/output headers to internal set names used in ZEN-garden.
+
+    This class defines standard header names for the input and 
+    output files of ZEN-garden. It provides a mapping between the column headers
+    of input/output files and internal set names used in the code. For 
+    example, the class attribute "set_nodes" (default value "node") means that
+    any input csv file with column header "node" will be interpreted as 
+    containing elements of the internal set "set_nodes". 
+
+    Inherits from:
+        :class:`Subscriptable` - Provides dictionary-like access to attributes 
+        and allows input data handling via Pydantic's BaseModel
     """
+
     set_nodes: str = "node"
     set_edges: str = "edge"
     set_location: str = "location"


### PR DESCRIPTION
## Changes proposed in this Pull Request

I improved the documentation of the default configuration code. This included writting a docstring for the module, and writting better docstrings for some of the classes within the module. The docstrings now also clearly show inheritance.

In addition to the docstrings, I restructured the Sphynx documentation a bit to allow easier custom-configuration of the API docs. In particular, custom automodule scripts can now be placed in the `files\api\modules` folder and referenced as demonstrated in the `files\api\models.rst`. This allows authors of the documentation to, for example, specify individual flags and options for different classes being documented. I added some code to the Sphynx `conf.py` and the `make.bat` so that files in the `files\api\generated` folder get deleted in every "make clean" and thus regenerated when the documentation is built. In contrast, custom files in `files\api\modules` are kept. This enables us to not push the generated files while still giving us flexibility to manually overwrite the api files.


## Checklist
Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.
