### PR TITLE
bug fix for reading out scenarios with decimal point in their name

### DIFF
--- a/tests/testcases/run_test.py
+++ b/tests/testcases/run_test.py
@@ -471,6 +471,8 @@ def test_4d(config, folder_path):
     # read the results and check again
     res = Results(os.path.join("outputs", data_set_name))
     compare_variables_results(data_set_name, res, folder_path)
+    # test functions get_total() and get_full_ts()
+    check_get_total_get_full_ts(res)
 
 
 def test_5a(config, folder_path):

--- a/tests/testcases/test_variables.json
+++ b/tests/testcases/test_variables.json
@@ -1893,6 +1893,16 @@
                     "index": ["natural_gas_boiler", "power", "DE", 0],
                     "value": 0.008
                 }
+            ],
+            "flow_import": [
+                {
+                    "index": ["natural_gas", "CH", 0],
+                    "value": 11.0
+                },
+                {
+                    "index": ["natural_gas", "DE", 0],
+                    "value": 110.0
+                }
             ]
         },
         "scenario_1_p00_000_price_import_1.6_reference_year_2023": {

--- a/zen_garden/postprocess/results/solution_loader.py
+++ b/zen_garden/postprocess/results/solution_loader.py
@@ -818,17 +818,15 @@ def get_df_from_path(path: str, component_name: str, version: str, data_type: Li
 
     return ans
 
+
 def _get_time_steps_file(scenario):
     """
     Helper-function that returns the name of the time steps file of a scenario.
     :param scenario:
     :return: time_steps_file_name
     """
-    time_steps_file_name = [
-        i.split(".")[0]
-        for i in os.listdir(scenario.path)
-        if "dict_all_sequence_time_steps" in i and ".lock" not in i
-    ]
+    time_steps_file_name = [os.path.splitext(i)[0] for i in os.listdir(scenario.path)
+                            if 'dict_all_sequence_time_steps' in i and '.lock' not in i]
     time_steps_file_name = np.unique(time_steps_file_name)
     assert len(time_steps_file_name) == 1, f"Multiple time steps files found: {time_steps_file_name}"
     time_steps_file_name = time_steps_file_name[0]


### PR DESCRIPTION
Closes #860

## Changes proposed in this Pull Request
Reading out the time steps from the results had a bug when there was a decimal point in the scenario name. Pull request fixes this issue. 

### PR structure
- [x] The PR has a descriptive title.
- [x] The corresponding issue is linked with # in the PR description.

### Code quality
- [x] Tests for new features were added:
  - [x] A new test folder is added or an existing test folder is adapted
  - [x] The test is added to `run_tests.py` and `docu_test_cases.md`
  - [x] The tested variables are added to `test_variables.json`
  - [x] Code changes have been tested locally and all tests pass
