### PR TITLE
Require python < 3.14

### DIFF
--- a/docs/files/quick_start/installation.rst
+++ b/docs/files/quick_start/installation.rst
@@ -30,10 +30,6 @@ You can quickly create an environment with the following command::
 
 Replace ``<your_env_name>`` with the name of your environment.
 
-.. warning::
-    Gurobi currently does not support Python version 3.13. We therefore 
-    recommend using Python 3.12.
-
 Activate the environment with the following command::
 
   conda activate <your_env_name>
@@ -50,6 +46,10 @@ To test whether the installation was successful, type:
     
 into the command prompt. This will print a list of all installed packages. You 
 should see ``zen_garden`` in the list.
+
+
+.. warning::
+    ZEN-garden currently only supports Python versions 3.11 through 3.13.
 
 
 .. _installation.activate:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
   ]
 # do not change version manually! Done by bump2version
 version = "2.6.14"
-requires-python= ">=3.11"
+requires-python= ">=3.11,<3.14"
 description="ZEN-garden is an optimization model of energy systems and value chains."
 readme = "README.md"
 license = { file = "LICENSE.txt" }

--- a/zen_garden_env.yml
+++ b/zen_garden_env.yml
@@ -4,7 +4,7 @@ channels:
   - gurobi
 dependencies:
   - pip
-  - python
+  - python=3.13
   - pip:
       - -e .[dev,vis,gurobipy,docs]
 


### PR DESCRIPTION
Not all dependencies support Python 3.14, which was only released a few days ago. With Python 3.14, the package currently failed to install and thus failed the tests.

We should revisit this issue in the future and update the requirements as soon as Python 3.14 is supported.

## Checklist
Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.

### Code quality
- [x] Newly introduced dependencies are added to `pyproject.toml`.

### Documentation
- [x] Other changes are documented in the corresponding section of the documentation
