### PR TITLE
Create tag after bumpversion

### DIFF
--- a/.github/workflows/bump_and_release.yml
+++ b/.github/workflows/bump_and_release.yml
@@ -3,7 +3,7 @@ name: Bump and Release
 # Define when to run
 on:
   push:
-    branches: bumpversion
+    branches: main
 
 # Env variables
 env:
@@ -44,6 +44,8 @@ jobs:
     if: ${{ github.repository == 'ZEN-universe/ZEN-garden' && needs.check_nobump.outputs.nobump == 'false' }}
     runs-on: ubuntu-latest
     needs: [check_nobump]
+    # outputs:
+    #   new_ver: ${{ steps.bv.outputs.new_ver }}
     env:
       NO_BUMP: ${{ needs.check_nobump.outputs.nobump }}
     steps:
@@ -93,6 +95,12 @@ jobs:
           echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
           git diff
 
+      - name: Get commit title
+        run: |
+          COMMIT_TITLE=$(git log -n 1 --pretty=format:"%s")
+          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
+
+
       - name: Check for changes after bump
         run: |
           git log --oneline -n 2
@@ -109,7 +117,7 @@ jobs:
           token: ${{ secrets.PULL_REQUEST_PAT }}
           title: ${{ env.COMMIT_TITLE }}
           body: "Automated version bump #skiptests"
-          base: bumpversion
+          base: main
           delete-branch: true  # optional: auto-delete branch after merge
 
       - name: Check outputs
@@ -168,6 +176,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Needed for tags and full history
+          ref: ${{github.ref}}
 
       - name: Set up Git
         run: |
@@ -177,19 +186,33 @@ jobs:
           
       - name: Get version number
         run: |
-          VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['tool']['poetry']['version'])")
+          COMMIT_SUBJECT=$(git log -n 1 --pretty=format:"%s")
+          echo "commit subject: $COMMIT_SUBJECT"
+
+          # Extract the second version using grep with a regular expression
+          VERSION=$(echo "$COMMIT_SUBJECT" | grep -oP '\d+\.\d+\.\d+(?=\s*\()')
+
+          # Split the version into major, minor, and patch components
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          # Output the results
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Version: $VERSION"
+          echo "Major version: $MAJOR"
+          echo "Minor version: $MINOR"
+          echo "Patch version: $PATCH"
+
           
       - name: Create and push tag
         run: |
-          git tag -a "v$VERSION" -m "Version $VERSION"
-          git push usptream --tags
+          echo "version: $env.VERSION"
+          git tag -a "v${{ env.VERSION }}" -m "Automated release for version v${{ env.VERSION }}"
+          git push origin --tags
 
   release:
     if: ${{ github.repository == 'ZEN-universe/ZEN-garden' }}
     name: "Create Github Release"
-    needs: bump_version
+    needs: [create_tag, bump_version]
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.get-latest-tag.outputs.tag }}

--- a/.github/workflows/pytest_with_conda.yml
+++ b/.github/workflows/pytest_with_conda.yml
@@ -7,7 +7,7 @@ on:
 
   pull_request:
     branches: 
-      - bumpversion
+      - main
     types: [opened, edited, synchronize]
 
 # Env variables


### PR DESCRIPTION
## Changes proposed in this Pull Request

The previous version of the Github actions pipeline did not create a  tag for each new version. This caused the release to fail, since no tag was identified. I created a new GitHub action job  `create_tag` that manually creates a tag. It reads the current version number from the bumpversion commit message and then pushes that tag to the bumpversion commit.


## Checklist
### PR structure
- [x] The PR has a descriptive title.

