### PR TITLE
Fix coverage badge in github actions

### DIFF
--- a/.github/workflows/bump_and_release.yml
+++ b/.github/workflows/bump_and_release.yml
@@ -117,7 +117,7 @@ jobs:
           token: ${{ secrets.PULL_REQUEST_PAT }}
           title: ${{ env.COMMIT_TITLE }}
           body: "Automated version bump #skiptests"
-          base: ${{github.ref}}
+          base: main
           delete-branch: true  # optional: auto-delete branch after merge
 
       - name: Check outputs

--- a/.github/workflows/pytest_with_conda.yml
+++ b/.github/workflows/pytest_with_conda.yml
@@ -10,6 +10,10 @@ on:
       - main
     types: [opened, edited, synchronize]
 
+  push:
+    branches:
+      - main
+
 # Env variables
 env:
   CACHE_NUMBER: 0  # increase to reset cache manually
@@ -138,21 +142,21 @@ jobs:
 #          coverage report -m
 
       - name: Extract Coverage
-        if: ${{ always() && matrix.label == 'linux-64' && env.SKIPTESTS == 'false' }} # include always to overwrite cancel on failure of previous step
+        if: ${{ always() && matrix.label == 'linux-64' && env.SKIPTESTS == 'false' && github.event_name == 'push'}} # include always to overwrite cancel on failure of previous step
         shell: bash -l {0}
         run: |
           echo "COVERAGE_INT=$(coverage report -m | grep TOTAL | grep -oE '[0-9]+%' | grep -oE '[0-9]+')" >> $GITHUB_ENV
           echo "COVERAGE_FLT=$(coverage report -m --precision=2 | grep TOTAL | grep -oE '[0-9]+\.[0-9]+')" >> $GITHUB_ENV
 
-      # - name: Create Coverage Badge
-      #   if: ${{ always() && matrix.label == 'linux-64' && env.SKIPTESTS == 'false' }}
-      #   uses: schneegans/dynamic-badges-action@v1.7.0
-      #   with:
-      #     auth: ${{ secrets.GIST_TOKEN }}
-      #     gistID: 30d479a5b4c591a63b7b0f41abbce6a0
-      #     filename: zen_garden_coverage.json
-      #     label: coverage
-      #     message: ${{ env.COVERAGE_FLT }}%
-      #     valColorRange: ${{ env.COVERAGE_INT }}
-      #     maxColorRange: 100
-      #     minColorRange: 0
+      - name: Create Coverage Badge
+        if: ${{ always() && matrix.label == 'linux-64' && env.SKIPTESTS == 'false' && github.event_name == 'push'}}
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 30d479a5b4c591a63b7b0f41abbce6a0
+          filename: zen_garden_coverage.json
+          label: coverage
+          message: ${{ env.COVERAGE_FLT }}%
+          valColorRange: ${{ env.COVERAGE_INT }}
+          maxColorRange: 100
+          minColorRange: 0


### PR DESCRIPTION
The coverage badge no longer seems to work. One reason why this may be is because the tests only run on pull_request rather than on a push to the main. I fixed this by making the tests now also run on pushes to the main branch. The coverage badge action now only runs in push events.

I also undid a previous change to the pull request action which caused an error.

### PR structure
- [x] The PR has a descriptive title.

