### PR TITLE
Fix bug in system.allow_investment

### DIFF
--- a/tests/testcases/run_test.py
+++ b/tests/testcases/run_test.py
@@ -669,4 +669,4 @@ def test_10a(folder_path):
 
 if __name__ == "__main__":
     folder_path = os.path.dirname(__file__)
-    test_1a(folder_path)
+    test_1g(folder_path)

--- a/tests/testcases/test_1g/set_carriers/heat/attributes.json
+++ b/tests/testcases/test_1g/set_carriers/heat/attributes.json
@@ -12,7 +12,7 @@
     "unit": "GW"
   },
   "price_shed_demand": {
-    "default_value": "inf",
+    "default_value": 100000,
     "unit": "kiloEuro/GWh"
   },
   "availability_import": {

--- a/tests/testcases/test_1g/set_carriers/natural_gas/availability_import.csv
+++ b/tests/testcases/test_1g/set_carriers/natural_gas/availability_import.csv
@@ -1,3 +1,3 @@
 node,time,availability_import
 CH,0,0
-CH,1,0
+CH,1,4

--- a/tests/testcases/test_1g/set_technologies/set_conversion_technologies/natural_gas_boiler/attributes.json
+++ b/tests/testcases/test_1g/set_technologies/set_conversion_technologies/natural_gas_boiler/attributes.json
@@ -68,7 +68,7 @@
   },
   "conversion_factor": {
       "natural_gas": {
-        "default_value": 1.1,
+        "default_value": 2,
         "unit": "GWh/GWh"
       }
   },

--- a/tests/testcases/test_1g/set_technologies/set_conversion_technologies/natural_gas_boiler/capacity_existing.csv
+++ b/tests/testcases/test_1g/set_technologies/set_conversion_technologies/natural_gas_boiler/capacity_existing.csv
@@ -1,3 +1,3 @@
 node,year_construction,capacity_existing
 DE,2022,100
-CH,2022,10
+CH,2022,6

--- a/tests/testcases/test_1g/set_technologies/set_transport_technologies/natural_gas_pipeline/attributes.json
+++ b/tests/testcases/test_1g/set_technologies/set_transport_technologies/natural_gas_pipeline/attributes.json
@@ -57,7 +57,7 @@
     "unit": "1"
   },
   "transport_loss_factor_linear": {
-    "default_value": 5e-05,
+    "default_value": 0,
     "unit": "1/km"
   },
   "capex_per_distance_transport": {

--- a/tests/testcases/test_1g/set_technologies/set_transport_technologies/natural_gas_pipeline/capacity_existing.csv
+++ b/tests/testcases/test_1g/set_technologies/set_transport_technologies/natural_gas_pipeline/capacity_existing.csv
@@ -1,2 +1,2 @@
 edge,year_construction,capacity_existing
-DE-CH,2022,20
+DE-CH,2022,10

--- a/tests/testcases/test_variables.json
+++ b/tests/testcases/test_variables.json
@@ -516,33 +516,43 @@
             "flow_import": [
                 {
                     "index": ["natural_gas", "DE", 0],
-                    "value": 121.287796
+                    "value": 210
+                },
+                {
+                    "index": ["natural_gas", "DE", 1],
+                    "value": 210
+                },
+                {
+                    "index": ["natural_gas", "CH", 0],
+                    "value": 0.0
                 },
                 {
                     "index": ["natural_gas", "CH", 1],
-                    "value": 0.0
+                    "value": 2.0
                 }
             ],
-            "carbon_emissions_carrier": [
+            "shed_demand": [
+                {
+                    "index": ["heat", "DE", 0],
+                    "value": 0.0
+                },
                 {
                     "index": ["heat", "DE", 1],
                     "value": 0.0
-                }
-            ],
-            "flow_conversion_output": [
-                {
-                    "index": ["natural_gas_boiler", "heat", "DE", 0],
-                    "value": 100.0
                 },
                 {
-                    "index": ["natural_gas_boiler", "heat", "DE", 1],
-                    "value": 100.0
+                    "index": ["heat", "CH", 0],
+                    "value": 5.0
+                },
+                {
+                    "index": ["heat", "CH", 1],
+                    "value": 4.0
                 }
             ],
             "flow_conversion_input": [
                 {
-                    "index": ["natural_gas_boiler", "natural_gas", "DE", 0],
-                    "value": 110.0
+                    "index": ["natural_gas_boiler", "natural_gas", "CH", 1],
+                    "value": 12.0
                 }
             ],
             "capacity": [
@@ -552,6 +562,10 @@
                 },
                 {
                     "index": ["natural_gas_boiler", "power", "CH", 0],
+                    "value": 6.0
+                },
+                {
+                    "index": ["natural_gas_pipeline", "power", "DE-CH", 0],
                     "value": 10.0
                 }
             ],

--- a/zen_garden/_internal.py
+++ b/zen_garden/_internal.py
@@ -71,7 +71,8 @@ def main(config, dataset_path=None, job_index=None, folder_output_path=None):
                 if phase == 'operation' and not config.system.include_operation_only_phase:
                     continue
                 StringUtils.print_optimization_progress(scenario, steps_horizon, step, system=config.system)
-                optimization_setup.set_phase_configurations(phase)
+                if optimization_setup.system.include_operation_only_phase:
+                    optimization_setup.set_phase_configurations(phase)
                 # overwrite time indices
                 optimization_setup.overwrite_time_indices(step)
                 # create optimization problem


### PR DESCRIPTION
The setting system.allow_investment was being overwritten by code for the setting system.include_operaton_only_phase. Investment was therefore always being allowed in one-phase simulations, regardless of what was specified in the system.allow_investment. This commit fixes this bug.

Furthermore, the previous test for system.allow_investment was not effective since the test result was the same regardless of whether system.allow_investment was true or false. This commit introduces a new test scenario that remedies this issue.

## Checklist
Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.

### Code quality
- [x] Tests for new features were added:
  - [x] A new test folder is added or an existing test folder is adapted
  - [x] The test is added to `run_tests.py` and `docu_test_cases.md`
  - [x] The tested variables are added to `test_variables.json`
- [x] Code changes have been tested locally and all tests pass


