### PR TITLE
Add new cli entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,7 @@ Zenodo = "https://zenodo.org/api/records/13385110"
 
 [tool.pytest.ini_options]
 addopts = "-n auto"
+
+[project.scripts]
+zen-garden = "zen_garden.__main__:run_module"
+zen-viz = "zen_garden.visualization:parse_arguments_and_run"


### PR DESCRIPTION
The following commands can now be used in the command line terminal:

- `zen-garden` refers to `python -m zen_garden`
- `zen-viz`  refers to `python -m zen_garden.visualization` #1112

### PR structure
- [x] The PR has a descriptive title.
- [x] The corresponding issue is linked with # in the PR description.

### Code quality
- [x] Newly introduced dependencies are added to `pyproject.toml`.


