### PR TITLE
slice old results with index and get index names

### DIFF
--- a/zen_garden/postprocess/results/results.py
+++ b/zen_garden/postprocess/results/results.py
@@ -673,6 +673,27 @@ class Results:
             return ""
         return component.doc
 
+    def get_index_names(self, component_name: str, scenario_name: Optional[str] = None) -> list[str]:
+        """
+        Docstring for get_index_names
+        
+        :param self: Description
+        :param component_name: Description
+        :type component_name: str
+        :param scenario_name: Description
+        :type scenario_name: Optional[str]
+        :return: Description
+        :rtype: list[str]
+        """
+        if scenario_name is None:
+            scenario_name = next(iter(self.solution_loader.scenarios.keys()))
+        scenario = self.solution_loader.scenarios[scenario_name]
+        if component_name not in scenario.components:
+            logging.warning(f"Component {component_name} not found and the index names cannot be returned.")
+            return []
+        component = scenario.components[component_name]
+        return component.index_names
+
     def get_years(self, scenario_name: Optional[str] = None) -> list[int]:
         """
         Extracts the years of a given Scenario. If no scenario is given, a random one is taken.

--- a/zen_garden/postprocess/results/solution_loader.py
+++ b/zen_garden/postprocess/results/solution_loader.py
@@ -10,10 +10,13 @@ import h5py  # type: ignore
 import pint
 import pandas as pd
 import numpy as np
+import logging
+
 from typing import Optional, Any,Literal
 from enum import Enum
 from functools import cache
 from zen_garden.default_config import Analysis, System, Solver
+from zen_garden.utils import slice_df_by_index
 
 class ComponentType(Enum):
     parameter: str = "parameter"
@@ -788,6 +791,8 @@ def get_df_from_path(path: str, component_name: str, version: str, data_type: Li
 
     if check_if_v1_leq_v2(version,"v0"):
         pd_read = pd.read_hdf(path, component_name + f"/{data_type}")
+        if len(index) > 0:
+            pd_read = slice_df_by_index(pd_read,index)
     else:
         if data_type == "dataframe":
             try:

--- a/zen_garden/utils.py
+++ b/zen_garden/utils.py
@@ -262,6 +262,33 @@ def reformat_slicing_index(index, component) -> tuple[str]:
 
     return ref_index
 
+def slice_df_by_index(df,index_tuple) -> dict:
+    """ recreates the slicing index from a tuple of strings and slices the dataframe accordingly
+    :param df: dataframe to be sliced
+    :param index_tuple: tuple of strings representing the slicing index
+    :return: sliced dataframe
+    """
+    index = {}
+    for index_str in index_tuple:
+        if " in " in index_str:
+            key, value_str = index_str.split(" in ")
+            key = key.strip("'")
+            value = eval(value_str)
+        elif " == " in index_str:
+            key, value_str = index_str.split(" == ")
+            key = key.strip("'")
+            value = eval(value_str)
+        else:
+            continue
+        index[key] = value
+    for key in index:
+        if key in df.index.names:
+            if isinstance(index[key], list):
+                df = df.loc[df.index.get_level_values(key).isin(index[key])]
+            else:
+                df = df.xs(index[key], level=key, drop_level=False)
+    return df
+
 def get_label_position(obj,label:int):
     """ Get dict of index and coordinate for variable or constraint labels."""
     name_element = obj.get_name_by_label(int(label))


### PR DESCRIPTION
## Changes proposed in this Pull Request
better handling of the index in the results:
- retrieve index names with `r.get_index_names(<component_name>,<scenario_name>)`
- slice with index even if old result version (now slicing the df instead of directly at the h5 file)

## Checklist
Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.

### Code quality
- [x] Code changes have been tested locally and all tests pass
