### PR TITLE
avoid KeyError when indexing with a non-existing index on the old results format

### DIFF
--- a/zen_garden/utils.py
+++ b/zen_garden/utils.py
@@ -351,6 +351,8 @@ def slice_df_by_index(df,index_tuple) -> dict:
             if isinstance(index[key], list):
                 df = df.loc[df.index.get_level_values(key).isin(index[key])]
             else:
+                if index[key] not in df.index.get_level_values(key):
+                    df = pd.DataFrame(columns=df.columns)  # return empty dataframe if value not in index
                 df = df.xs(index[key], level=key, drop_level=False)
     return df
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
avoid KeyError when indexing with a non-existing index on the old results format.
Returns an empty df


## Checklist
Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.
