### PR TITLE
Remove cache annotations in solution_loader.

### DIFF
--- a/zen_garden/postprocess/results/cache.py
+++ b/zen_garden/postprocess/results/cache.py
@@ -1,0 +1,52 @@
+import functools
+
+
+class ConditionalCache:
+    """
+    Decorator to conditionally cache method results based on an instance flag.
+    If the flag is True, the method results are cached using functools.cache.
+    Otherwise, the method is called normally without caching.
+
+    ## Usage
+    ```
+    class MyClass:
+        def __init__(self, enable_cache: bool):
+            self.enable_cache = enable_cache
+
+        @ConditionalCache('enable_cache')
+        def my_method(self, ...):
+            # method implementation
+            pass
+    ```
+    """
+
+    def __init__(self, flag_name: str):
+        self.flag_name = flag_name
+
+    def __call__(self, func):
+        self.func = func
+        functools.update_wrapper(self, func)
+        return self
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        # Check if caching is enabled for this instance and get the bound method
+        enable_cache = getattr(instance, self.flag_name, False)
+        bound_func = self.func.__get__(instance, owner)
+
+        # If caching is disabled, return the original bound method
+        if not enable_cache:
+            return bound_func
+
+        # Check if the cached version already exists
+        cache_attr = f"__cached_{self.func.__name__}"
+        cached_func = getattr(instance, cache_attr, None)
+        if cached_func is not None:
+            return cached_func
+
+        # Create and store the cached version of the method
+        cached_func = functools.cache(bound_func)
+        setattr(instance, cache_attr, cached_func)
+        return cached_func

--- a/zen_garden/postprocess/results/results.py
+++ b/zen_garden/postprocess/results/results.py
@@ -28,7 +28,7 @@ class Results:
     """
     The Results class is used to extract and process the results of a model run.
     """
-    def __init__(self, path: str):
+    def __init__(self, path: str, enable_cache: bool = True):
         """
         Initializes the Results class.
 
@@ -36,7 +36,7 @@ class Results:
         """
         assert os.path.exists(path), f"The output folder {Path(path).absolute()} does not exist."
         assert len(os.listdir(path)) > 0, f"The output folder {Path(path).absolute()} is empty."
-        self.solution_loader = SolutionLoader(path)
+        self.solution_loader = SolutionLoader(path, enable_cache=enable_cache)
         self.has_scenarios = len(self.solution_loader.scenarios) > 1
         first_scenario = next(iter(self.solution_loader.scenarios.values()))
         self.name = Path(first_scenario.analysis.dataset).name

--- a/zen_garden/postprocess/results/solution_loader.py
+++ b/zen_garden/postprocess/results/solution_loader.py
@@ -14,9 +14,9 @@ import logging
 
 from typing import Optional, Any,Literal
 from enum import Enum
-from functools import cache
 from zen_garden.default_config import Analysis, System, Solver
 from zen_garden.utils import slice_df_by_index
+from .cache import ConditionalCache
 
 class ComponentType(Enum):
     parameter: str = "parameter"
@@ -304,11 +304,12 @@ class SolutionLoader():
     Implementation of a SolutionLoader.
     """
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, enable_cache: bool = True) -> None:
         self.path = path
         assert len(os.listdir(path)) > 0, f"Path {path} is empty."
         self._scenarios: dict[str, Scenario] = self._read_scenarios()
         self._series_cache: dict[str, "pd.Series[Any]"] = {}
+        self.enable_cache = enable_cache
 
     @property
     def scenarios(self) -> dict[str, Scenario]:
@@ -395,6 +396,7 @@ class SolutionLoader():
         series.index.names = new_index_names
         return series
 
+    @ConditionalCache("enable_cache")
     def get_component_data(
         self,
         scenario: Scenario,
@@ -491,6 +493,7 @@ class SolutionLoader():
 
         return ans
 
+    @ConditionalCache("enable_cache")
     def get_timestep_duration(
         self, scenario: Scenario, component: Component
     ) -> "pd.Series[Any]":
@@ -521,8 +524,7 @@ class SolutionLoader():
 
         return time_step_duration
 
-
-
+    @ConditionalCache("enable_cache")
     def get_timesteps(
         self, scenario: Scenario, component: Component, year: int
     ) -> "pd.Series[Any]":
@@ -553,6 +555,7 @@ class SolutionLoader():
 
         return ans
 
+    @ConditionalCache("enable_cache")
     def get_timesteps_of_years(
         self, scenario: Scenario, ts_type: TimestepType, years: tuple
     ) -> "pd.DataFrame | pd.Series[Any]":


### PR DESCRIPTION
I found that the `@cache` annotations in solution_loader causes excessive memory usage in ZEN-temple, because all the data remains in memory after a request has been resolved.

These caches are ineffective because of three reasons:
- As far as I can tell, the underlying computation is not computationally intensive, i.e., the process spends more time transferring data than doing actual work on the data. Therefore, we don't speed up a computation by caching results.
- The generated data is huge (around 500 MB for component `storage_level` in `technology_optimism_pessimism`). Caches are most effective if the cached data is small.
- The caches aren't called repeatedly. In fact, per request they are called only once.

Therefore, I suggest to remove these annotations and rely on more course-grained caches in ZEN-temple that are much smaller.

### PR structure
- [x] The PR has a descriptive title.