### PR TITLE
Fix combine dataseries when series_to_concat is empty.

### DIFF
--- a/zen_garden/postprocess/results/solution_loader.py
+++ b/zen_garden/postprocess/results/solution_loader.py
@@ -379,6 +379,9 @@ class SolutionLoader():
                 series_to_concat.append(current_mf)
                 break
 
+        if len(series_to_concat) == 0:
+            return pd.Series(dtype=float)
+
         return pd.concat(series_to_concat)
 
     def _concatenate_raw_dataseries(


### PR DESCRIPTION
## Summary

The following code snippet raises an exception.

```python
import os
from zen_garden.postprocess.results import Results
SOLUTION_FOLDER = "../zen-temple/outputs"
solution_name = "technology_optimism_pessimism.Optimism_light"
solution_folder = os.path.join(SOLUTION_FOLDER, *solution_name.split("."))
results = Results(solution_folder, enable_cache=False)
results.get_total("flow_conversion_output", index={'carrier': 'biomass'})
```

It turns out the method `_combine_dataseries` in `solution_loader.py` throws an exception when `series_to_concat` is empty. I fixed that by adding an if-condition. This makes the above example to return an empty series instead of raising an exception.


## Detailed list of changes

List all changes proposed in the pull request in the format `<type>: <description>` (**mandatory**). This list will be used to update the changelog. Valid types include `fix`, `feat`, `docs`, `chore`, and `breaking`.

The first sentence of the description should be written in the imperative tense (e.g., "Add new feature" or "Clean existing code file"). Subsequent sentences may have any format; however, the description must consist of only one paragraph (no newline characters).

An example list is shown below. Update these sections to match the changes proposed in the pull request.:

- fix: return empty series when there are no series to concatenate in `_combine_dataseries` in `solution_loader.py`.


## Checklist

Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.
