### PR TITLE
added warning for file paths and link to Python.org

### DIFF
--- a/docs/files/quick_start/building_models.rst
+++ b/docs/files/quick_start/building_models.rst
@@ -46,12 +46,22 @@ more detail. The ``.csv`` files are optional and can be omitted if the default
 values are sufficient. More detail on the use of default values and overwriting 
 them can be found in :ref:`input_structure.attribute_files` and :ref:`input_structure.overwrite_defaults`.
 
-
 .. tip::
   Notation: this guide uses angle brackets ``<>`` whenever to denote places 
   that contain user-specific information. For example, the file path ``<data>``
   indicates that users should replace this text with the file path to their 
-  own dataset directory. 
+  own dataset directory.
+
+.. warning::
+    File paths with more than 260 characters in total length may not be accepted by
+    Windows systems. To avoid this issue, we recommend using shorter names for carriers
+    and technologies. For Windows 10 and newer, a longer file path limit can be
+    enabled by following the instructions from the `Microsoft support
+    <https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry>`_.
+
+.. warning::
+    Special characters are not allowed in file or folder names and will lead to errors
+    when running the model.
 
 .. _building.first_model:
 

--- a/docs/files/quick_start/installation.rst
+++ b/docs/files/quick_start/installation.rst
@@ -18,9 +18,11 @@ command prompt.
 
 We recommend working from a conda environment for the installation. If you have 
 not installed Anaconda, you can download it from the 
-`Anaconda website <https://docs.anaconda.com/anaconda/install/>`_. You can check 
-if you have Anaconda installed by running the following command in  a terminal 
-(MacOS)/command prompt (Windows)
+`Anaconda website <https://docs.anaconda.com/anaconda/install/>`_.
+For the general installer and beginner documentation of Python, please visit
+`Python.org <https://www.python.org/about/gettingstarted/>`_.
+You can check if you have Anaconda installed by running the following command in
+a terminal (MacOS)/command prompt (Windows)
 
 .. code:: shell
 


### PR DESCRIPTION
## Summary

Documentation changes to hint at restrictions for the file paths and to guide visitors to Python.org 

Closes # (if applicable).
#1104 
#1105 

## Detailed list of changes

- docs: add warnings and link to Python. New Python users find a link to Python.org. Also added warnings for the following issues: File paths that exceed 260 characters may lead to errors with Windows and special characters are not compatible with ZEN-garden.

## Checklist

### PR structure
- [x] The PR has a descriptive title.
- [x] The corresponding issue is linked with `#` in the PR description.
- [x] A detailed list of changes is provided.
