### PR TITLE
Remove line causing TypeError.

### DIFF
--- a/zen_garden/postprocess/results/solution_loader.py
+++ b/zen_garden/postprocess/results/solution_loader.py
@@ -887,9 +887,7 @@ def get_df_from_path(
         index = tuple()
 
     if check_if_v1_leq_v2(version, "v0"):
-        pd_read = pd.read_hdf(path, component_name + f"/{data_type}")
-        with h5py.File(path, "r") as h5_file:
-            h5_file[component_name + f"/{data_type}"][:]
+        pd_read = pd.read_hdf(path, f"{component_name}/{data_type}")
         if len(index) > 0:
             pd_read = slice_df_by_index(pd_read, index)
     elif check_if_v1_leq_v2(version, "v2"):


### PR DESCRIPTION
## Summary

The following snippet used in ZEN-temple causes a TypeError: `TypeError: Accessing a group is done with bytes or str, not <class 'slice'>`.

```python
import os
from zen_garden.postprocess.results import Results

SOLUTION_FOLDER = "../zen-temple"
solution_name = "european_electricity_heating_transition.perfect_foresight"
solution_folder = os.path.join(SOLUTION_FOLDER, "outputs", *solution_name.split("."))
results = Results(solution_folder)
results.get_df("set_reference_carriers",scenario_name=None)
```

I noticed that the removed lines have no effect. Therefore, I think they can be removed.

## Detailed list of changes

- fix: remove lines causing TypeError in ZEN-temple

## Checklist

Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.

### Code quality
- [x] Code changes have been tested locally and all tests pass.
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.