### PR TITLE
Fix docu for plugin architecture

### DIFF
--- a/docs/files/api/plugin_system.rst
+++ b/docs/files/api/plugin_system.rst
@@ -1,0 +1,8 @@
+Plugin system
+--------------
+
+.. autosummary::
+   :toctree: generated
+
+    zen_garden.plugin_system.events
+    zen_garden.plugin_system.loader

--- a/docs/files/plugins/available_plugins.rst
+++ b/docs/files/plugins/available_plugins.rst
@@ -4,3 +4,4 @@
 Available Plugins
 ############################
 
+At the moment, there are no plugins available.

--- a/docs/files/plugins/overview.rst
+++ b/docs/files/plugins/overview.rst
@@ -8,9 +8,6 @@ The ZEN-garden plugin system lets you extend core behaviour without altering the
 main codebase. Plugins are regular Python packages that register callback
 functions for events triggered `zen_garden.events.EventPublisher`.
 
-Key points
-----------
-
 - Plugins live under `zen_garden.plugins.<plugin_name>.plugin` and expose a
   `config` dictionary for configuration.
 - The loader `register_plugins` imports selected plugins and merges
@@ -22,6 +19,6 @@ Key points
 See also
 --------
 
-- Developer guide: `Implementing plugins <dev_guide.implementing_plugins>`_
-- Available plugins: `Available plugins <plugins.available_plugins>`_
-- Configurations: `Configuration options for plugins <configuration.plugins>`_
+- Developer guide: :ref:`Implementing plugins <dev_guide.implementing_plugins>`
+- Available plugins: :ref:`Available plugins <plugins.available_plugins>`
+- Configurations: :ref:`Configuration options for plugins <configuration.plugins>`

--- a/docs/files/references/api_reference.rst
+++ b/docs/files/references/api_reference.rst
@@ -22,6 +22,7 @@ ZEN-garden
    ../api/model
    ../api/postprocess
    ../api/preprocess
+   ../api/plugin_system
 
 
 

--- a/docs/files/zen_garden_in_detail/configurations.rst
+++ b/docs/files/zen_garden_in_detail/configurations.rst
@@ -130,6 +130,9 @@ description of the scaling algorithm.
 
 .. _configuration.plugins:
 
+Plugins
+---------
+
 Activating plugins and passing configurations to plugins is done by modifying the ``plugins`` key
 in the ``config.json``. The key name corresponds to the plugin name to be activated.
 the dictonary under this key defines the configuration for the plugin.


### PR DESCRIPTION
## Summary

Fixes broken links in docu and adds the plugin documentation to the api reference


## Detailed list of changes

- docs: update links in plugin documentation
- docs: add plugin architecture to api reference

## Checklist

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.

### Code quality
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.
