### PR TITLE
Install `pre-commit` to run `ruff` and `black` before committing.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-fix
+        name: ruff --fix
+        entry: ruff check --fix
+        language: system
+        types: [python]
+
+      - id: black
+        name: black
+        entry: black
+        language: system
+        types: [python]

--- a/docs/files/developer_guide/contributing.rst
+++ b/docs/files/developer_guide/contributing.rst
@@ -4,10 +4,10 @@
 Contribution Guide
 ########################
 
-Thank you for your interest in contributing to ZEN-garden! 🎉  
+Thank you for your interest in contributing to ZEN-garden! 🎉
 Community contributions are highly appreciated and help improve the project.
 
-Before submitting changes, please read the following guidelines.  
+Before submitting changes, please read the following guidelines.
 There are several ways to contribute:
 
 * :ref:`Reporting bugs or suggesting new features <contributing.issues>`
@@ -22,7 +22,7 @@ Reporting Bugs or Suggesting Features
 =====================================
 
 If you discover a bug, have a feature request, or want to suggest an improvement,
-please create an issue in the 
+please create an issue in the
 `GitHub repository <https://github.com/ZEN-universe/ZEN-garden/issues>`_.
 
 When creating an issue, please follow these guidelines:
@@ -56,7 +56,7 @@ All contributions follow the **fork-and-pull request workflow**.
 6. Submit a **Pull Request (PR)** from your fork to the upstream repository.
 
 .. note::
-  
+
    Contributors **must not create branches directly on the upstream repository**.
    All development should take place in personal forks.
 
@@ -66,7 +66,7 @@ All contributions follow the **fork-and-pull request workflow**.
 Coding Standards
 ----------------
 
-ZEN-garden follows the `PEP 8 <https://peps.python.org/pep-0008/>`_ 
+ZEN-garden follows the `PEP 8 <https://peps.python.org/pep-0008/>`_
 Python style guide with a few project-specific conventions.
 
 **General naming rules:**
@@ -102,7 +102,7 @@ Python style guide with a few project-specific conventions.
 Code Formatting
 ---------------
 
-All Python code must be formatted using *Black* before submitting a pull 
+All Python code must be formatted using *Black* before submitting a pull
 request.
 
 To format the code, run the following command in the repository root:
@@ -135,13 +135,30 @@ Some issues can be fixed automatically:
 
     ruff check . --fix
 
+.. _contributing.pre_commit_hooks:
+
+Pre-commit Hooks
+----------------
+
+`pre-commit <https://pre-commit.com/>`_ is a tool to setup and manage Git
+hooks, that is scripts that are executed around git events such as before
+creating a commit. We can use this tool to let the commands ``ruff check --fix``
+and ``black`` run before every commit to ensure that all files are formatted
+properly. To setup pre-commit properly execute the following commands once:
+
+.. code:: shell
+
+    pip install -e[dev]
+    pre-commit install
+
+Afterwards, whenever you run git commit, *Ruff* and *Black* are executed.
 
 .. _contributing.branch_protections:
 
 Branch Protection Rules
 -----------------------
 
-The **main branch** of ZEN-garden is protected to ensure code quality and 
+The **main branch** of ZEN-garden is protected to ensure code quality and
 stability.
 
 The following rules apply:
@@ -152,7 +169,7 @@ The following rules apply:
 
 2. **Pull requests must be up to date**
 
-   If your branch is outdated, update it by merging or rebasing with 
+   If your branch is outdated, update it by merging or rebasing with
    the latest version of the main branch.
 
 3. **All tests must pass**

--- a/docs/files/developer_guide/installation.rst
+++ b/docs/files/developer_guide/installation.rst
@@ -4,14 +4,14 @@
 Installation for Developers
 ###########################
 
-If you want to work on the codebase, you can fork and clone the repository from 
+If you want to work on the codebase, you can fork and clone the repository from
 `GitHub <https://github.com/ZEN-universe/ZEN-garden>`_.
 
-If it's your first time using GitHub, register at `<https://github.com/>`_. 
+If it's your first time using GitHub, register at `<https://github.com/>`_.
 After you have created an account, you can fork and clone the repository.
 
-Navigate to `<https://github.com/ZEN-universe/ZEN-garden>`_ on Github and click 
-on the "Fork" button at the top right corner of the page to create a copy of the 
+Navigate to `<https://github.com/ZEN-universe/ZEN-garden>`_ on Github and click
+on the "Fork" button at the top right corner of the page to create a copy of the
 repository under your account and select yourself as the owner.
 
 .. image:: ../figures/developer_guide/create_fork.png
@@ -21,22 +21,22 @@ repository under your account and select yourself as the owner.
 
 **Clone your forked repository:**
 
-Clone your forked repository by running the following lines in `Git-Bash 
+Clone your forked repository by running the following lines in `Git-Bash
 <https://git-scm.com/downloads>`_::
 
     git clone git@github.com:<your-username>/ZEN-garden.git
     cd ZEN-garden
 
-Substitute ``<your-username>`` with your Github username. If you gave the forked 
-repository a different name, replace ``ZEN-garden`` with the name of your 
+Substitute ``<your-username>`` with your Github username. If you gave the forked
+repository a different name, replace ``ZEN-garden`` with the name of your
 repository.
 
 .. note::
-    If you get the permissions error "Permission denied (publickey)", you will 
-    need to create the SSH key. Follow the instructions on `how to generate an 
-    SSH key <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key>`_ 
-    and then `how to add it to your account <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account#adding-a-new-ssh-key-to-your-account>`_. 
-    You will not need to add the SSH key to the Agent, so only follow the first 
+    If you get the permissions error "Permission denied (publickey)", you will
+    need to create the SSH key. Follow the instructions on `how to generate an
+    SSH key <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key>`_
+    and then `how to add it to your account <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account#adding-a-new-ssh-key-to-your-account>`_.
+    You will not need to add the SSH key to the Agent, so only follow the first
     website until before `Adding your SSH key to the ssh-agent <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent>`_
 
 **Track the upstream repository:**
@@ -56,34 +56,38 @@ Track the upstream repository by running the following lines in Git-Bash::
 Open the Anaconda Prompt application. This is a terminal window provided by
 Anaconda which allows you to run Anaconda commands.
 
-In the Anaconda Prompt, change the directory to the root directory of your 
-local ZEN-garden repository i.e. the folder where the file 
+In the Anaconda Prompt, change the directory to the root directory of your
+local ZEN-garden repository i.e. the folder where the file
 ``zen_garden_env.yml`` is located::
 
   cd <path_to_zen_garden_repo>
 
-Now you can install the conda environment for zen-garden with the following 
+Now you can install the conda environment for zen-garden with the following
 command::
 
   conda env create -f zen_garden_env.yml
 
-The installation may take a couple of minutes. If the installation was 
-successful, you can see the environment at 
+The installation may take a couple of minutes. If the installation was
+successful, you can see the environment at
 ``C:\Users\<username>\anaconda3\envs`` or wherever Anaconda is installed.
 
+In the new environment, setup the pre-commit hooks by running the following command in the Anaconda Prompt::
+
+  pre-commit install
+
 .. note::
-    If you forked the ZEN-garden repository and created the environment from 
-    ``zen_garden_env.yml``, then the environment will by default be 
+    If you forked the ZEN-garden repository and created the environment from
+    ``zen_garden_env.yml``, then the environment will by default be
     called ``zen-garden-env``.
 
 .. note::
-    We strongly recommend working with conda environments. When installing the 
-    zen-garden conda environment via the ``zen_garden_env.yml``, the zen-garden 
-    package, as well as all other dependencies, are installed automatically. 
+    We strongly recommend working with conda environments. When installing the
+    zen-garden conda environment via the ``zen_garden_env.yml``, the zen-garden
+    package, as well as all other dependencies, are installed automatically.
 
 **Next steps**
 
-You have now successfully installed ZEN-garden as a developer. To familiarize 
-yourself with the model, you may now follow the quick start guide on 
-:ref:`building a model <building.building>` and :ref:`running a model 
+You have now successfully installed ZEN-garden as a developer. To familiarize
+yourself with the model, you may now follow the quick start guide on
+:ref:`building a model <building.building>` and :ref:`running a model
 <running.running>`.

--- a/docs/files/zen_garden_in_detail/configurations.rst
+++ b/docs/files/zen_garden_in_detail/configurations.rst
@@ -10,7 +10,7 @@ Configurations
 System Configurations
 =====================
 
-The ``system.json`` defines the structure of the energy system. The following 
+The ``system.json`` defines the structure of the energy system. The following
 table summarizes the available system settings and their default values.
 
 .. csv-table:: System Settings
@@ -20,25 +20,25 @@ table summarizes the available system settings and their default values.
     :delim: ;
 
 
-Per default, the technology selection is empty. You must define the set of 
-technologies you want to investigate in your system. Only technologies selected 
-in ``system.json`` are added to the optimization problem. You can flexibly 
-select any subset of the technologies available in your ``set_technologies`` 
-folder. Selecting a technology that is not defined in your input data will raise 
+Per default, the technology selection is empty. You must define the set of
+technologies you want to investigate in your system. Only technologies selected
+in ``system.json`` are added to the optimization problem. You can flexibly
+select any subset of the technologies available in your ``set_technologies``
+folder. Selecting a technology that is not defined in your input data will raise
 an error.
 
 Per default, all nodes defined in ``energy_system/set_nodes.csv`` are added.
-You can reduce the number of nodes by selecting a subset of nodes in your 
-``system.json``. In addition, you can specify the starting year 
-(``reference_year``), the time horizon (``optimized_years``), and the 
+You can reduce the number of nodes by selecting a subset of nodes in your
+``system.json``. In addition, you can specify the starting year
+(``reference_year``), the time horizon (``optimized_years``), and the
 interyearly resolution (``interval_between_years``) in the ``system.json``.
 
 Per default, each year is represented by 8760 timesteps of length 1h.
-You can change the interyearly resolution by modifying the 
-``unaggregated_time_steps_per_year``. To reduce the complexity, timeseries 
-aggregation can be used (``conduct_time_series_aggregation``) to reduce the 
-number of time steps. Per default, the number of timesteps is reduced to 10 
-(``aggregated_time_steps_per_year``). :ref:`t_tsa.t_tsa` and :ref:`t_tsa.time_parameters` provide a detailed description of 
+You can change the interyearly resolution by modifying the
+``unaggregated_time_steps_per_year``. To reduce the complexity, timeseries
+aggregation can be used (``conduct_time_series_aggregation``) to reduce the
+number of time steps. Per default, the number of timesteps is reduced to 10
+(``aggregated_time_steps_per_year``). :ref:`t_tsa.t_tsa` and :ref:`t_tsa.time_parameters` provide a detailed description of
 the time representation and the time parameters.
 
 
@@ -47,8 +47,8 @@ the time representation and the time parameters.
 Config Configurations
 =====================
 
-This section describes all configurations which can be set in the 
-``config.json`` file. The ``config.json`` file generally contains a list 
+This section describes all configurations which can be set in the
+``config.json`` file. The ``config.json`` file generally contains a list
 of two dictionaries: ``analysis`` and ``solver``. Each of these dictionaries
 contains configurations which the user can specify. The lists below contain
 a complete list of configurations for each dictionary.
@@ -58,8 +58,8 @@ a complete list of configurations for each dictionary.
 Analysis
 --------
 
-The dataset, the objective function and the solver are selected in the 
-``analysis`` dictionary of ``config.json``. The following table summarizes the 
+The dataset, the objective function and the solver are selected in the
+``analysis`` dictionary of ``config.json``. The following table summarizes the
 available ``analysis`` settings and their default values:
 
 .. csv-table:: Analysis Settings
@@ -68,12 +68,12 @@ available ``analysis`` settings and their default values:
     :widths: 10 10 10 20
     :delim: ;
 
-The settings of the timeseries aggregation algorithm are also specified in the 
-``analysis`` section. The following table summarizes the available timeseries 
-aggregation settings and their default values. For further information on how to 
-use the timeseries aggregation, see :ref:`t_tsa.using_the_tsa`. In addition, 
-:ref:`t_tsa.t_tsa` and :ref:`t_tsa.time_parameters` 
-provide helpful information on the time representation and the time parameters 
+The settings of the timeseries aggregation algorithm are also specified in the
+``analysis`` section. The following table summarizes the available timeseries
+aggregation settings and their default values. For further information on how to
+use the timeseries aggregation, see :ref:`t_tsa.using_the_tsa`. In addition,
+:ref:`t_tsa.t_tsa` and :ref:`t_tsa.time_parameters`
+provide helpful information on the time representation and the time parameters
 in ZEN-garden.
 
 .. csv-table:: Timeseries Aggregation Settings
@@ -88,7 +88,7 @@ in ZEN-garden.
 Solver
 ------
 
-Solver settings are also specified in the ``config.json``. The following table 
+Solver settings are also specified in the ``config.json``. The following table
 summarizes the available solver settings and their default values.
 
 .. csv-table:: Solver Settings
@@ -97,14 +97,14 @@ summarizes the available solver settings and their default values.
     :widths: 10 10 10 20
     :delim: ;
 
-Per default the open-source solver `HiGHS <https://highs.dev/>`_ is used. You 
-can change the solver by modifying the ``solver`` key. Solver-specific settings 
-are passed via the ``solver_settings``. Please refer to the solver documentation 
+Per default the open-source solver `HiGHS <https://highs.dev/>`_ is used. You
+can change the solver by modifying the ``solver`` key. Solver-specific settings
+are passed via the ``solver_settings``. Please refer to the solver documentation
 for the available solver settings for the solver that you are using.
 
-For linear optimization problems, the dual variables can be computed and saved 
-by selecting ``save_duals=True``. Saving the duals helps understand the 
-optimality of the solution, but it also strongly increases the file size of the 
+For linear optimization problems, the dual variables can be computed and saved
+by selecting ``save_duals=True``. Saving the duals helps understand the
+optimality of the solution, but it also strongly increases the file size of the
 output files. Reduced costs can be saved by setting ``save_reduced_costs=True``.
 This can increase significantly the file size of output files.
 The parameters of the optimization problem can be saved by
@@ -112,7 +112,7 @@ selecting ``save_parameters=True``. If you only want to save specific
 parameters, you can specify them in the ``selected_saved_parameters`` list. The
 same applies to the variables, duals and reduced costs, which can be specified in the
 ``selected_saved_variables``, ``selected_saved_duals``, and ``selected_saved_reduced_costs``
- lists, respectively. The name of the duals corresponds to the name of the constraints.
+lists, respectively. The name of the duals corresponds to the name of the constraints.
 
 
 .. note::
@@ -122,10 +122,10 @@ same applies to the variables, duals and reduced costs, which can be specified i
     The visualization platform may not work properly if you do not save the
     parameters and variables.
 
-You can analyze the numerics of your optimization problem via 
-``analyze_numerics``. In addition, a scaling algorithm is available. Per 
-default, four iterations of the scaling algorithm are conducted without 
-including the values of the right-hand-side. :ref:`t_scaling.t_scaling` provides a detailed 
+You can analyze the numerics of your optimization problem via
+``analyze_numerics``. In addition, a scaling algorithm is available. Per
+default, four iterations of the scaling algorithm are conducted without
+including the values of the right-hand-side. :ref:`t_scaling.t_scaling` provides a detailed
 description of the scaling algorithm.
 
 .. _configuration.plugins:
@@ -136,5 +136,3 @@ Plugins
 Activating plugins and passing configurations to plugins is done by modifying the ``plugins`` key
 in the ``config.json``. The key name corresponds to the plugin name to be activated.
 the dictonary under this key defines the configuration for the plugin.
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ dev = [
     "pytest-cov",
     "black==25.12.0",
     "ruff==0.14.13",
-    "mypy==1.19.1"
+    "mypy==1.19.1",
+    "pre-commit",
 ]
 
 vis = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "ordered-set",
     "pyogrio",
     "psutil",
-    "linopy",
+    "linopy==0.6.7",
     "requests",
     "ipykernel",
     "zen-temple>=0.7.3"

--- a/tests/testcases/run_test.py
+++ b/tests/testcases/run_test.py
@@ -36,11 +36,11 @@ def compare_variables_results(test_model: str, results: Results, folder_path: st
         folder_path: The path to the folder containing the file with the
             correct variables
     """
-    # import json file containing selected variable values of test model 
+    # import json file containing selected variable values of test model
     # collection
     with open(os.path.join(folder_path, "test_variables.json")) as f:
         test_variables = json.load(f)
-    # dictionary to store variable names, indices, values and test values of 
+    # dictionary to store variable names, indices, values and test values of
     # variables which don't match the test values
     failed_variables = defaultdict(dict)
     compare_counter = 0
@@ -93,7 +93,7 @@ def compare_variables_results(test_model: str, results: Results, folder_path: st
                 f"No variables have been compared in {test_model}. If not "
                 f"intended, check the test_variables.json file."
             ),
-            stacklevel=2
+            stacklevel=2,
         )
 
 
@@ -109,7 +109,7 @@ def check_get_total_get_full_ts(
 
     Args:
         get_doc:
-        discount_to_first_step: Apply annuity to first year of interval or 
+        discount_to_first_step: Apply annuity to first year of interval or
             entire interval
         year: Specific year
         specific_scenario: Specific scenario
@@ -394,7 +394,7 @@ def test_3d(folder_path):
         folder_output=os.path.join(folder_path, "outputs"),
     )
 
-    # compare the variables of the optimization setup ## disabled for myopic 
+    # compare the variables of the optimization setup ## disabled for myopic
     # foresight tests!
     # compare_variables(data_set_name, optimization_setup, folder_path)
     # read the results and check again
@@ -413,7 +413,7 @@ def test_3e(folder_path):
         folder_output=os.path.join(folder_path, "outputs"),
     )
 
-    # compare the variables of the optimization setup ## disabled for myopic 
+    # compare the variables of the optimization setup ## disabled for myopic
     # foresight tests!
     # compare_variables(data_set_name, optimization_setup, folder_path)
     # read the results and check again
@@ -430,7 +430,7 @@ def test_3f(folder_path):
         folder_output=os.path.join(folder_path, "outputs"),
     )
 
-    # compare the variables of the optimization setup ## disabled for myopic 
+    # compare the variables of the optimization setup ## disabled for myopic
     # foresight tests!
     # compare_variables(data_set_name, optimization_setup, folder_path)
     # read the results and check again


### PR DESCRIPTION
## Summary

`pre-commit` is a useful tool to setup and manage git hooks, that is scripts that are executed around git events such as before creating a commit. We can use this tool to let the commands `ruff --fix` and `black` run before every commit to ensure that all files are formatted properly.

To setup pre-commit properly execute the following commands once:

```bash
pip install -e[dev]
pre-commit install
```

Afterwards, whenever you run `git commit`, ruff and black are executed.

## Detailed list of changes

- feat: install `pre-commit` to run `ruff --fix` and `black` before creating new commits.

## Checklist

Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.


### Code quality
- [x] Newly introduced dependencies are added to `pyproject.toml`.
- [x] Code changes have been tested locally and all tests pass.
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.