### PR TITLE
fix tsam version due to breaking changes in 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pint",
     "tables",
     "pydantic",
-    "tsam",
+    "tsam<4.0",
     "h5py",
     "filelock",
     "ordered-set",


### PR DESCRIPTION
## Summary

Restrict TSAM dependency to pre-4.0 releases to avoid breaking API changes introduced in TSAM 4.0. Update dependency constraint in pyproject.toml (and any CI/test pins) so the project uses a TSAM 3.x-compatible release.


## Detailed list of changes

fix: Pin the tsam dependency to <4.0.0 in pyproject.toml to avoid runtime and API breakage caused by TSAM 4.0. Update relevant CI/test dependency pins so test runs install a TSAM release compatible with the current ZEN-garden codebase.

## Checklist

### PR structure

- [x] The PR has a descriptive title.
- [x]  A detailed list of changes is provided.