### PR TITLE
Fix construction year in operations wrapper.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,7 @@ zen_garden_env/
 .coverage
 *runscript.py
 *test.py
-/tests/testcases/test_1k__operation/*
-/tests/testcases/test_7b__operation/*
+/tests/testcases/*__operation*
 
 # pytest monitor
 .pymon

--- a/zen_garden/wrapper/utils.py
+++ b/zen_garden/wrapper/utils.py
@@ -182,7 +182,9 @@ def format_capacity_addition(
     suffix: str,
     location_name: str,
 ) -> pd.DataFrame:
-    """Format the capacity addition DataFrame for consistency in column names.
+    """Format the capacity addition DataFrame for consistency.
+
+    Adjusts column names and subtracts one year from the year of capacity addition.
 
     Args:
         capacity_addition_tech (pd.DataFrame): The DataFrame with capacity
@@ -194,13 +196,22 @@ def format_capacity_addition(
     Returns:
         pd.DataFrame: The formatted DataFrame with the correct column names.
     """
-    return capacity_addition_tech.rename(
+    # rename columns for consistency
+    df = capacity_addition_tech.rename(
         columns={
             "location": location_name,
             capacity_type: f"capacity_existing{suffix}",
             "year": "year_construction",
         }
     )
+
+    # Adjust year_construction to be one year earlier than the year of capacity addition
+    # This is required to ensure consistency in lifetime with the capacity planning
+    # model. For example, wind installed in 2025 with 25 year lifetime would otherwise
+    # be included in the operational problem for 2050 but not in the capacity problem.
+    df["year_construction"] = df["year_construction"] - 1
+
+    return df
 
 
 def aggregate_capacity(


### PR DESCRIPTION
## Summary

Changes the construction time in the operation wrapper to `year-1` to ensure consistency with the capacity planning model. Closes # 1257.

## Detailed list of changes

- fix: adjust construction time in the operations wrapper to ensure consistency with the capacity planning model. 

## Checklist

Please check all items that apply. If an item is not applicable, please remove it from the list.

### PR structure
- [x] The PR has a descriptive title.
- [x] The corresponding issue is linked with `#` in the PR description.
- [x] A detailed list of changes is provided.


### Code quality
- [x] Code changes have been tested locally and all tests pass.
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.
