### PR TITLE
Add missing data input header for retrofitting technologies.

### DIFF
--- a/zen_garden/default_config.py
+++ b/zen_garden/default_config.py
@@ -176,6 +176,7 @@ class HeaderDataInputs(ConfigBase):
     set_technologies: str = "technology"
     set_technologies_existing: str = "technology_existing"
     set_capacity_types: str = "capacity_type"
+    set_retrofitting_technologies: str = "technology"
 
 
 class System(ConfigBase):


### PR DESCRIPTION
## Summary

There was no header for retrofitting technologies. This PR fixes that.


## Detailed list of changes

- feat: add missing header for set_retrofitting_technologies.

